### PR TITLE
Removed const from OAHashMap iterator value

### DIFF
--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -300,7 +300,7 @@ public:
 		bool valid;
 
 		const TKey *key;
-		const TValue *value;
+		TValue *value;
 
 	private:
 		uint32_t pos;


### PR DESCRIPTION
Removed const from OAHashMap iterator value to allows to mutate the value while iterating over it.