### PR TITLE
Add tests for DataBuffer and introduce some improvements

### DIFF
--- a/modules/network_synchronizer/data_buffer.cpp
+++ b/modules/network_synchronizer/data_buffer.cpp
@@ -278,42 +278,42 @@ real_t DataBuffer::add_real(real_t p_input, CompressionLevel p_compression_level
 	ERR_FAIL_COND_V(is_reading == true, p_input);
 
 	const real_t integral = Math::floor(p_input);
-	const real_t fractional = Math::fmod(p_input, 1);
+	const real_t fractional = ABS(Math::fmod(p_input, 1));
 
 	const real_t added_integral = add_int(integral, p_compression_level);
-	const real_t added_fractional = add_unit_real(fractional, COMPRESSION_LEVEL_1);
+	const real_t added_fractional = add_positive_unit_real(fractional, COMPRESSION_LEVEL_1);
 
-	return added_integral + added_fractional;
+	return added_integral > 0 ? added_integral + added_fractional : added_integral - added_fractional;
 }
 
 real_t DataBuffer::read_real(CompressionLevel p_compression_level) {
 	ERR_FAIL_COND_V(is_reading == false, 0.0);
 
 	const real_t integral = read_int(p_compression_level);
-	const real_t fractional = read_unit_real(COMPRESSION_LEVEL_1);
+	const real_t fractional = read_positive_unit_real(COMPRESSION_LEVEL_1);
 
-	return integral + fractional;
+	return integral > 0 ? integral + fractional : integral - fractional;
 }
 
 real_t DataBuffer::add_precise_real(real_t p_input, CompressionLevel p_compression_level) {
 	ERR_FAIL_COND_V(is_reading == true, p_input);
 
 	const real_t integral = Math::floor(p_input);
-	const real_t fractional = Math::fmod(p_input, 1);
+	const real_t fractional = ABS(Math::fmod(p_input, 1));
 
-	const real_t ri = add_int(integral, p_compression_level);
-	const real_t rf = add_unit_real(fractional, COMPRESSION_LEVEL_0);
+	const real_t added_integral = add_int(integral, p_compression_level);
+	const real_t added_fractional = add_positive_unit_real(fractional, COMPRESSION_LEVEL_0);
 
-	return ri + rf;
+	return added_integral > 0 ? added_integral + added_fractional : added_integral - added_fractional;
 }
 
 real_t DataBuffer::read_precise_real(CompressionLevel p_compression_level) {
 	ERR_FAIL_COND_V(is_reading == false, 0.0);
 
 	const real_t integral = read_int(p_compression_level);
-	const real_t fractional = read_unit_real(COMPRESSION_LEVEL_0);
+	const real_t fractional = read_positive_unit_real(COMPRESSION_LEVEL_0);
 
-	return integral + fractional;
+	return integral > 0 ? integral + fractional : integral - fractional;
 }
 
 real_t DataBuffer::add_positive_unit_real(real_t p_input, CompressionLevel p_compression_level) {
@@ -520,9 +520,9 @@ Vector3 DataBuffer::add_normalized_vector3(Vector3 p_input, CompressionLevel p_c
 #endif
 	ERR_FAIL_COND_V(is_reading == true, p_input);
 
-	const uint64_t x_axis = add_real(p_input.x, p_compression_level);
-	const uint64_t y_axis = add_real(p_input.y, p_compression_level);
-	const uint64_t z_axis = add_real(p_input.z, p_compression_level);
+	const real_t x_axis = add_unit_real(p_input.x, p_compression_level);
+	const real_t y_axis = add_unit_real(p_input.y, p_compression_level);
+	const real_t z_axis = add_unit_real(p_input.z, p_compression_level);
 
 	return Vector3(x_axis, y_axis, z_axis);
 }
@@ -530,9 +530,9 @@ Vector3 DataBuffer::add_normalized_vector3(Vector3 p_input, CompressionLevel p_c
 Vector3 DataBuffer::read_normalized_vector3(CompressionLevel p_compression_level) {
 	ERR_FAIL_COND_V(is_reading == false, Vector3());
 
-	const uint64_t x_axis = read_real(p_compression_level);
-	const uint64_t y_axis = read_real(p_compression_level);
-	const uint64_t z_axis = read_real(p_compression_level);
+	const real_t x_axis = read_unit_real(p_compression_level);
+	const real_t y_axis = read_unit_real(p_compression_level);
+	const real_t z_axis = read_unit_real(p_compression_level);
 
 	return Vector3(x_axis, y_axis, z_axis);
 }

--- a/modules/network_synchronizer/data_buffer.h
+++ b/modules/network_synchronizer/data_buffer.h
@@ -79,18 +79,18 @@ public:
 	///
 	/// ## Real
 	/// The floating point part has a precision of ~0.020%
-	/// COMPRESSION_LEVEL_0: 73 bits are used - The integral part has a range of -9223372036854775808 / 9223372036854775807
-	/// COMPRESSION_LEVEL_1: 41 bits are used - The integral part has a range of -2147483648 / 2147483647
-	/// COMPRESSION_LEVEL_2: 25 bits are used - The integral part has a range of -32768 / 32767
-	/// COMPRESSION_LEVEL_3: 17 bits are used - The integral part has a range of -128 / 127
+	/// COMPRESSION_LEVEL_0: 72 bits are used - The integral part has a range of -9223372036854775808 / 9223372036854775807
+	/// COMPRESSION_LEVEL_1: 40 bits are used - The integral part has a range of -2147483648 / 2147483647
+	/// COMPRESSION_LEVEL_2: 24 bits are used - The integral part has a range of -32768 / 32767
+	/// COMPRESSION_LEVEL_3: 16 bits are used - The integral part has a range of -128 / 127
 	///
 	///
 	/// ## Precise real
 	/// The floating point part has a precision of ~0.005%
-	/// COMPRESSION_LEVEL_0: 75 bits are used - The integral part has a range of -9223372036854775808 / 9223372036854775807
-	/// COMPRESSION_LEVEL_1: 43 bits are used - The integral part has a range of -2147483648 / 2147483647
-	/// COMPRESSION_LEVEL_2: 27 bits are used - The integral part has a range of -32768 / 32767
-	/// COMPRESSION_LEVEL_3: 19 bits are used - The integral part has a range of -128 / 127
+	/// COMPRESSION_LEVEL_0: 74 bits are used - The integral part has a range of -9223372036854775808 / 9223372036854775807
+	/// COMPRESSION_LEVEL_1: 42 bits are used - The integral part has a range of -2147483648 / 2147483647
+	/// COMPRESSION_LEVEL_2: 26 bits are used - The integral part has a range of -32768 / 32767
+	/// COMPRESSION_LEVEL_3: 18 bits are used - The integral part has a range of -128 / 127
 	///
 	///
 	/// ## Positive unit real
@@ -124,10 +124,10 @@ public:
 	///
 	///
 	/// ## Normalized Vector2
-	/// COMPRESSION_LEVEL_0: 11 bits are used - Max loss 0.17°
-	/// COMPRESSION_LEVEL_1: 10 bits are used - Max loss 0.35°
-	/// COMPRESSION_LEVEL_2: 9 bits are used - Max loss 0.7°
-	/// COMPRESSION_LEVEL_3: 8 bits are used - Max loss 1.1°
+	/// COMPRESSION_LEVEL_0: 12 bits are used - Max loss 0.17°
+	/// COMPRESSION_LEVEL_1: 11 bits are used - Max loss 0.35°
+	/// COMPRESSION_LEVEL_2: 10 bits are used - Max loss 0.7°
+	/// COMPRESSION_LEVEL_3: 9 bits are used - Max loss 1.1°
 	///
 	///
 	/// ## Vector3
@@ -148,9 +148,9 @@ public:
 	///
 	/// ## Normalized Vector3
 	/// COMPRESSION_LEVEL_0: 11 * 3 bits are used - Max loss ~0.005% per axis
-	/// COMPRESSION_LEVEL_1: 10 * 3 bits are used - Max loss ~0.020% per axis
-	/// COMPRESSION_LEVEL_2: 8 * 3 bits are used - Max loss ~0.793% per axis
-	/// COMPRESSION_LEVEL_3: 6 * 3 bits are used - Max loss ~3.333% per axis
+	/// COMPRESSION_LEVEL_1: 9 * 3 bits are used - Max loss ~0.020% per axis
+	/// COMPRESSION_LEVEL_2: 7 * 3 bits are used - Max loss ~0.793% per axis
+	/// COMPRESSION_LEVEL_3: 5 * 3 bits are used - Max loss ~3.333% per axis
 	///
 	/// ## Variant
 	/// It's dynamic sized. It's not possible to compress it.

--- a/modules/network_synchronizer/tests/test_data_buffer.h
+++ b/modules/network_synchronizer/tests/test_data_buffer.h
@@ -122,6 +122,7 @@ TEST_CASE("[Modules][DataBuffer] Int") {
 }
 
 TEST_CASE("[Modules][DataBuffer] Real") {
+	constexpr real_t epsilon = 0.00196;
 	DataBuffer buffer;
 	DataBuffer::CompressionLevel compression_level = {};
 	real_t value = {};
@@ -172,23 +173,24 @@ TEST_CASE("[Modules][DataBuffer] Real") {
 		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
 
 		SUBCASE("[Modules][DataBuffer] Positive") {
-			value = 2147483647.55;
+			value = 922337203685477.55;
 		}
 		SUBCASE("[Modules][DataBuffer] Zero") {
 			value = 0.0;
 		}
 		SUBCASE("[Modules][DataBuffer] Negative") {
-			value = -9223372036854775807.55;
+			value = -9223372036854775808.55;
 		}
 	}
 
 	buffer.begin_write(0);
-	CHECK_MESSAGE(buffer.add_real(value, compression_level) == doctest::Approx(value).epsilon(0.020), "Should return the same value");
+	CHECK_MESSAGE(buffer.add_real(value, compression_level) == doctest::Approx(value).epsilon(epsilon), "Should return the same value");
 	buffer.begin_read();
-	CHECK_MESSAGE(buffer.read_real(compression_level) == doctest::Approx(value).epsilon(0.020), "Should read the same value");
+	CHECK_MESSAGE(buffer.read_real(compression_level) == doctest::Approx(value).epsilon(epsilon), "Should read the same value");
 }
 
 TEST_CASE("[Modules][DataBuffer] Precise real") {
+	constexpr real_t epsilon = 0.00049;
 	DataBuffer buffer;
 	DataBuffer::CompressionLevel compression_level = {};
 	real_t value = {};
@@ -239,20 +241,20 @@ TEST_CASE("[Modules][DataBuffer] Precise real") {
 		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
 
 		SUBCASE("[Modules][DataBuffer] Positive") {
-			value = 2147483647.555;
+			value = 922337203685477.555;
 		}
 		SUBCASE("[Modules][DataBuffer] Zero") {
 			value = 0.0;
 		}
 		SUBCASE("[Modules][DataBuffer] Negative") {
-			value = -9223372036854775807.555;
+			value = -9223372036854775808.555;
 		}
 	}
 
 	buffer.begin_write(0);
-	CHECK_MESSAGE(buffer.add_precise_real(value, compression_level) == doctest::Approx(value).epsilon(0.005), "Should return the same value");
+	CHECK_MESSAGE(buffer.add_precise_real(value, compression_level) == doctest::Approx(value).epsilon(epsilon), "Should return the same value");
 	buffer.begin_read();
-	CHECK_MESSAGE(buffer.read_precise_real(compression_level) == doctest::Approx(value).epsilon(0.005), "Should read the same value");
+	CHECK_MESSAGE(buffer.read_precise_real(compression_level) == doctest::Approx(value).epsilon(epsilon), "Should read the same value");
 }
 
 TEST_CASE("[Modules][DataBuffer] Positive unit real") {
@@ -384,6 +386,432 @@ TEST_CASE("[Modules][DataBuffer] Unit real") {
 	CHECK_MESSAGE(buffer.add_unit_real(value, compression_level) == doctest::Approx(value).epsilon(epsilon), "Should return the same value");
 	buffer.begin_read();
 	CHECK_MESSAGE(buffer.read_unit_real(compression_level) == doctest::Approx(value).epsilon(epsilon), "Should read the same value");
+}
+
+TEST_CASE("[Modules][DataBuffer] Vector2") {
+	constexpr real_t epsilon = 0.00196;
+	DataBuffer buffer;
+	DataBuffer::CompressionLevel compression_level = {};
+	Vector2 value = {};
+
+	SUBCASE("[Modules][DataBuffer] Compression level 3") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_3;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(127.55, 127.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-128.55, -128.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(127.55, -128.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(127.55, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-128.55, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 2") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_2;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(32767.55, 32767.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-32768.55, -32768.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(32767.55, -32768.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(32767.55, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-32768.55, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 1") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_1;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(2147483647.55, 2147483647.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-2147483648.55, -2147483648.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(2147483647.55, -2147483648.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(2147483647.55, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-2147483648.55, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 0") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(922337203685477.55, 922337203685477.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-9223372036854775808.55, -9223372036854775808.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(922337203685477.55, -9223372036854775808.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(922337203685477.55, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-9223372036854775808.55, 0);
+		}
+	}
+
+	buffer.begin_write(0);
+	Vector2 added_value = buffer.add_vector2(value, compression_level);
+	CHECK_MESSAGE(added_value.x == doctest::Approx(value.x).epsilon(epsilon), "Added Vector2 should have the same x axis");
+	CHECK_MESSAGE(added_value.y == doctest::Approx(value.y).epsilon(epsilon), "Added Vector2 should have the same y axis");
+	buffer.begin_read();
+	Vector2 read_value = buffer.read_vector2(compression_level);
+	CHECK_MESSAGE(read_value.x == doctest::Approx(value.x).epsilon(epsilon), "Read Vector2 should have the same x axis");
+	CHECK_MESSAGE(read_value.y == doctest::Approx(value.y).epsilon(epsilon), "Read Vector2 should have the same y axis");
+}
+
+TEST_CASE("[Modules][DataBuffer] Precise Vector2") {
+	constexpr real_t epsilon = 0.00049;
+	DataBuffer buffer;
+	DataBuffer::CompressionLevel compression_level = {};
+	Vector2 value = {};
+
+	SUBCASE("[Modules][DataBuffer] Compression level 3") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_3;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(127.555, 127.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-128.555, -128.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(127.555, -128.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(127.555, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-128.555, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 2") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_2;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(32767.555, 32767.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-32768.555, -32768.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(32767.555, -32768.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(32767.555, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-32768.555, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 1") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_1;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(2147483647.555, 2147483647.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-2147483648.555, -2147483648.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(2147483647.555, -2147483648.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(2147483647.555, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-2147483648.555, 0);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 0") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector2(922337203685477.55, 922337203685477.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector2(0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector2(-9223372036854775808.555, -9223372036854775808.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and negative") {
+			value = Vector2(922337203685477.55, -9223372036854775808.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Positive and zero") {
+			value = Vector2(922337203685477.55, 0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative and zero") {
+			value = Vector2(-9223372036854775808.555, 0);
+		}
+	}
+
+	buffer.begin_write(0);
+	Vector2 added_value = buffer.add_precise_vector2(value, compression_level);
+	CHECK_MESSAGE(added_value.x == doctest::Approx(value.x).epsilon(epsilon), "Added Vector2 should have the same x axis");
+	CHECK_MESSAGE(added_value.y == doctest::Approx(value.y).epsilon(epsilon), "Added Vector2 should have the same y axis");
+	buffer.begin_read();
+	Vector2 read_value = buffer.read_precise_vector2(compression_level);
+	CHECK_MESSAGE(read_value.x == doctest::Approx(value.x).epsilon(epsilon), "Read Vector2 should have the same x axis");
+	CHECK_MESSAGE(read_value.y == doctest::Approx(value.y).epsilon(epsilon), "Read Vector2 should have the same y axis");
+}
+
+TEST_CASE("[Modules][DataBuffer] Vector3") {
+	constexpr real_t epsilon = 0.00196;
+	DataBuffer buffer;
+	DataBuffer::CompressionLevel compression_level = {};
+	Vector3 value = {};
+
+	SUBCASE("[Modules][DataBuffer] Compression level 3") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_3;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(127.55, 127.55, 127.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-128.55, -128.55, -128.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(127.55, 0, -128.55);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 2") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_2;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(32767.55, 32767.55, 32767.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-32768.55, -32768.55, -32768.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(32767.55, 0, -32768.55);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 1") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_1;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(2147483647.55, 2147483647.55, 2147483647.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-2147483648.55, -2147483648.55, -2147483648.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(2147483647.55, 0, -2147483648.55);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 0") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(922337203685477.55, 922337203685477.55, 922337203685477.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-9223372036854775808.55, -9223372036854775808.55, -9223372036854775807.55);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(922337203685477.55, 0, -9223372036854775808.55);
+		}
+	}
+
+	buffer.begin_write(0);
+	Vector3 added_value = buffer.add_vector3(value, compression_level);
+	CHECK_MESSAGE(added_value.x == doctest::Approx(value.x).epsilon(epsilon), "Added Vector3 should have the same x axis");
+	CHECK_MESSAGE(added_value.y == doctest::Approx(value.y).epsilon(epsilon), "Added Vector3 should have the same y axis");
+	CHECK_MESSAGE(added_value.z == doctest::Approx(value.z).epsilon(epsilon), "Added Vector3 should have the same z axis");
+	buffer.begin_read();
+	Vector3 read_value = buffer.read_vector3(compression_level);
+	CHECK_MESSAGE(read_value.x == doctest::Approx(value.x).epsilon(epsilon), "Read Vector3 should have the same x axis");
+	CHECK_MESSAGE(read_value.y == doctest::Approx(value.y).epsilon(epsilon), "Read Vector3 should have the same y axis");
+	CHECK_MESSAGE(read_value.z == doctest::Approx(value.z).epsilon(epsilon), "Read Vector3 should have the same z axis");
+}
+
+TEST_CASE("[Modules][DataBuffer] Precise Vector3") {
+	constexpr real_t epsilon = 0.00049;
+	DataBuffer buffer;
+	DataBuffer::CompressionLevel compression_level = {};
+	Vector3 value = {};
+
+	SUBCASE("[Modules][DataBuffer] Compression level 3") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_3;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(127.555, 127.555, 127.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-128.555, -128.555, -128.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(127.55, 0, -128.55);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 2") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_2;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(32767.555, 32767.555, 32767.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-32768.555, -32768.555, -32768.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(32767.555, 0, -32768.555);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 1") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_1;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(2147483647.555, 2147483647.555, 2147483647.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-2147483648.555, -2147483648.555, -2147483648.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(2147483647.555, 0, -2147483648.555);
+		}
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 0") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
+
+		SUBCASE("[Modules][DataBuffer] Positive") {
+			value = Vector3(922337203685477.555, 922337203685477.555, 922337203685477.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Zero") {
+			value = Vector3(0.0, 0.0, 0.0);
+		}
+		SUBCASE("[Modules][DataBuffer] Negative") {
+			value = Vector3(-9223372036854775808.555, -9223372036854775808.555, -9223372036854775808.555);
+		}
+		SUBCASE("[Modules][DataBuffer] Different axles") {
+			value = Vector3(922337203685477.555, 0, -9223372036854775808.555);
+		}
+	}
+
+	buffer.begin_write(0);
+	Vector3 added_value = buffer.add_precise_vector3(value, compression_level);
+	CHECK_MESSAGE(added_value.x == doctest::Approx(value.x).epsilon(epsilon), "Added Vector3 should have the same x axis");
+	CHECK_MESSAGE(added_value.y == doctest::Approx(value.y).epsilon(epsilon), "Added Vector3 should have the same y axis");
+	CHECK_MESSAGE(added_value.z == doctest::Approx(value.z).epsilon(epsilon), "Added Vector3 should have the same z axis");
+	buffer.begin_read();
+	Vector3 read_value = buffer.read_precise_vector3(compression_level);
+	CHECK_MESSAGE(read_value.x == doctest::Approx(value.x).epsilon(epsilon), "Read Vector3 should have the same x axis");
+	CHECK_MESSAGE(read_value.y == doctest::Approx(value.y).epsilon(epsilon), "Read Vector3 should have the same y axis");
+	CHECK_MESSAGE(read_value.z == doctest::Approx(value.z).epsilon(epsilon), "Read Vector3 should have the same z axis");
+}
+
+TEST_CASE("[Modules][DataBuffer] Normalized Vector3") {
+	const Vector3 value = Vector3(0.014278, 0.878079, 0.478303);
+	DataBuffer buffer;
+	DataBuffer::CompressionLevel compression_level = {};
+	real_t epsilon = {};
+
+	SUBCASE("[Modules][DataBuffer] Compression level 3") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_3;
+		epsilon = 0.033335;
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 2") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_2;
+		epsilon = 0.007935;
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 1") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_1;
+		epsilon = 0.00196;
+	}
+
+	SUBCASE("[Modules][DataBuffer] Compression level 0") {
+		compression_level = DataBuffer::COMPRESSION_LEVEL_0;
+		epsilon = 0.00049;
+	}
+
+	buffer.begin_write(0);
+	Vector3 added_value = buffer.add_normalized_vector3(value, compression_level);
+	CHECK_MESSAGE(added_value.x == doctest::Approx(value.x).epsilon(epsilon), "Added Vector3 should have the same x axis");
+	CHECK_MESSAGE(added_value.y == doctest::Approx(value.y).epsilon(epsilon), "Added Vector3 should have the same y axis");
+	CHECK_MESSAGE(added_value.z == doctest::Approx(value.z).epsilon(epsilon), "Added Vector3 should have the same z axis");
+	buffer.begin_read();
+	Vector3 read_value = buffer.read_normalized_vector3(compression_level);
+	CHECK_MESSAGE(read_value.x == doctest::Approx(value.x).epsilon(epsilon), "Read Vector3 should have the same x axis");
+	CHECK_MESSAGE(read_value.y == doctest::Approx(value.y).epsilon(epsilon), "Read Vector3 should have the same y axis");
+	CHECK_MESSAGE(read_value.z == doctest::Approx(value.z).epsilon(epsilon), "Read Vector3 should have the same z axis");
 }
 } // namespace TestDataBuffer
 


### PR DESCRIPTION
I've used `= {}` in my tests to turn off warnings in MSVC. I used it instead of simple values ​​to clarify that the value is not important (creates noise) and will be assigned in subcases.